### PR TITLE
fix: allow stdout to be empty when getting bin dir

### DIFF
--- a/lib/utils.mjs
+++ b/lib/utils.mjs
@@ -12,7 +12,7 @@ const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const binDir = cpSpawnSync('npm', ['bin'], {
   encoding: 'utf-8',
   cwd: rootDir.replace(new RegExp(`${path.sep}node_modules.*`), ''),
-}).stdout.trim()
+}).stdout?.trim()
 
 export const readJson = async (p) => JSON.parse(await readFile(p, 'utf-8'))
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
