### PR TITLE
feat: better support for cloning forked repos

### DIFF
--- a/lib/gh/workers/_common.mjs
+++ b/lib/gh/workers/_common.mjs
@@ -15,6 +15,11 @@ export const clone = ({ argv, item }) => [
         status === 1 && output.includes('already exists') && 0,
     },
   ],
+  // choose the forked repo as the default, for operations like template-oss-fix
+  // See https://github.com/cli/cli/issues/9261#issuecomment-2193936803
+  ['gh',
+    ['repo', 'set-default', `${item.owner}/${item.name}`],
+  ],
 ]
 
 export const checkout = ({ argv }) => [

--- a/lib/gh/workers/_common.mjs
+++ b/lib/gh/workers/_common.mjs
@@ -8,7 +8,8 @@ export const clone = ({ argv, item }) => [
   mkdirp({ argv, item }),
   [
     'gh',
-    ['repo', 'clone', `${item.owner}/${item.name}`],
+    // template-oss will use upstream over origin, so we supply an alternate remote name for forked repos
+    ['repo', 'clone', `${item.owner}/${item.name}`, '-u', 'parent'],
     {
       cwd: item.ownerDir,
       status: ({ status, output }) =>


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

By default the gh cli operates against the upstream repo when you run commands like `gh pr checkout ...`. For the purposes of stafftools, we want to operate against the forked repo, so we run `gh repo set-default npm/{name}`.

Tested with `node ./bin/gh.mjs template-oss-fix --install --filter 'name:json-parse-even-better-errors'` after removing `~/projects/npm/json-parse-even-better-errors`. Also tested with `node ./bin/gh.mjs repos clone --filter "name:agent"`, to ensure clone still works for non-forked repos.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Change to favor the upstream remote: https://github.com/npm/template-oss/issues/363

https://github.com/npm/json-parse-even-better-errors/pull/65

https://github.com/cli/cli/issues/9261#issuecomment-2193936803

https://github.com/cli/cli/discussions/6777