### PR TITLE
Update node engine and ci to 22

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -87,17 +87,11 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 18.0.0
-          - 18.x
-          - 20.x
+          - 22.0.0
           - 22.x
         exclude:
           - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 18.0.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 18.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 20.x
+            node-version: 22.0.0
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 22.x
     runs-on: ${{ matrix.platform.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,17 +64,11 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 18.0.0
-          - 18.x
-          - 20.x
+          - 22.0.0
           - 22.x
         exclude:
           - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 18.0.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 18.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 20.x
+            node-version: 22.0.0
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 22.x
     runs-on: ${{ matrix.platform.os }}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lib/"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=22.0.0"
   },
   "prettier": {
     "semi": false,


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Dependencies are starting to drop support for Node 18. This will let us accept more Dependabot PRs.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

https://github.com/npm/documentation/pull/1195

https://github.com/npm/stafftools/actions/runs/9861420107/job/27229820008?pr=135