### PR TITLE
feat: Avoid refixing successful template-oss PRs

### DIFF
--- a/lib/gh/workers/template-oss-fix.mjs
+++ b/lib/gh/workers/template-oss-fix.mjs
@@ -5,8 +5,15 @@ export const type = 'template-oss'
 
 export const filter = [
   `title: '@npmcli/template-oss'`,
-  (item, _, __, opts) =>
-    opts.argv.author ? opts.argv.author.includes(item.commitAuthor) : true,
+  (item, _, __, opts) => {
+    if (opts.argv.author && !opts.argv.author.includes(item.commitAuthor)) {
+      return false
+    }
+    if (opts.argv.statusIgnore && opts.argv.statusIgnore.includes(item.status)) {
+      return false
+    }
+    return true
+  },
 ]
 
 export const args = {
@@ -22,6 +29,15 @@ export const args = {
         default: ['npm-cli-bot', 'dependabot[bot]'],
         type: 'array',
         desc: 'Only fix PRs if the latest commit is this author',
+        coerce: (v) =>
+          !v.length || v[0] === 'null' || v[0] === 'false' || v[0] === 'ANY'
+            ? null
+            : v,
+      },
+      statusIgnore: {
+        default: ['SUCCESS', 'PENDING'],
+        type: 'array',
+        desc: 'Skip PRs if the latest commit has this status',
         coerce: (v) =>
           !v.length || v[0] === 'null' || v[0] === 'false' || v[0] === 'ANY'
             ? null

--- a/tap-snapshots/test/gh.mjs.test.cjs
+++ b/tap-snapshots/test/gh.mjs.test.cjs
@@ -853,11 +853,12 @@ npx -p @npmcli/stafftools gh graphql template-oss-fix
 Fix failing template-oss pull requests
 
 Command Options:
-      --query    path to a query file passed directly to gh api graphql  [string] [required]
-      --cache    how long for gh to cache the query  [string] [default: "1m"]
-      --report   shorthand for --template=report  [boolean] [default: false]
-      --message  Commit message to be used for template oss changes, with out the \`<TYPE>:\` prefix  [required] [default: "postinstall for dependabot template-oss PR"]
-      --author   Only fix PRs if the latest commit is this author  [array] [default: ["npm-cli-bot","dependabot[bot]"]]
+      --query         path to a query file passed directly to gh api graphql  [string] [required]
+      --cache         how long for gh to cache the query  [string] [default: "1m"]
+      --report        shorthand for --template=report  [boolean] [default: false]
+      --message       Commit message to be used for template oss changes, with out the \`<TYPE>:\` prefix  [required] [default: "postinstall for dependabot template-oss PR"]
+      --author        Only fix PRs if the latest commit is this author  [array] [default: ["npm-cli-bot","dependabot[bot]"]]
+      --statusIgnore  Skip PRs if the latest commit has this status  [array] [default: ["SUCCESS","PENDING"]]
 
 Global Options:
   -c, --cwd       base directory to run filesystem related commands  [string] [default: "$HOME/projects"]
@@ -1898,13 +1899,14 @@ npx -p @npmcli/stafftools gh template-oss template-oss-fix
 Fix failing template-oss pull requests
 
 Command Options:
-      --cache    how long for gh to cache the query  [string] [default: "1m"]
-      --repos    query to filter repos  [string] [required] [default: "org:npm topic:npm-cli fork:true archived:false"]
-      --table    shorthand for --template=table  [boolean] [default: false]
-      --confirm  shorthand for --template=confirm  [boolean] [default: false]
-      --report   shorthand for --template=report  [boolean] [default: false]
-      --message  Commit message to be used for template oss changes, with out the \`<TYPE>:\` prefix  [required] [default: "postinstall for dependabot template-oss PR"]
-      --author   Only fix PRs if the latest commit is this author  [array] [default: ["npm-cli-bot","dependabot[bot]"]]
+      --cache         how long for gh to cache the query  [string] [default: "1m"]
+      --repos         query to filter repos  [string] [required] [default: "org:npm topic:npm-cli fork:true archived:false"]
+      --table         shorthand for --template=table  [boolean] [default: false]
+      --confirm       shorthand for --template=confirm  [boolean] [default: false]
+      --report        shorthand for --template=report  [boolean] [default: false]
+      --message       Commit message to be used for template oss changes, with out the \`<TYPE>:\` prefix  [required] [default: "postinstall for dependabot template-oss PR"]
+      --author        Only fix PRs if the latest commit is this author  [array] [default: ["npm-cli-bot","dependabot[bot]"]]
+      --statusIgnore  Skip PRs if the latest commit has this status  [array] [default: ["SUCCESS","PENDING"]]
 
 Global Options:
   -c, --cwd       base directory to run filesystem related commands  [string] [default: "$HOME/projects"]


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

`template-oss-fix` previously returned open template-oss PRs regardless of status. If you continued it would rebase green PRs, leading to unnecessary churn and possibly resetting an approval.

I opted to make an exclusion list because commits can have a status of `null`, in the case of merge conflicts or the "Post Dependabot" commit not triggering a new CI run.

### Before

```
% npx -p @npmcli/stafftools@latest gh template-oss-fix --author null
Running worker "template-oss-fix" which will "Fix failing template-oss pull requests" on the following items:
✅  npm/abbrev-js                 chore: bump @npmcli/template-oss from 4.22.0 to 4.23.3
✅  npm/eslint-config             chore: bump @npmcli/template-oss from 4.23.2 to 4.23.3
✅  npm/hosted-git-info           chore: bump @npmcli/template-oss from 4.23.1 to 4.23.3
?   npm/hosted-git-info           chore: bump @npmcli/template-oss from 4.23.1 to 4.23.3
✅  npm/ignore-walk               chore: bump @npmcli/template-oss from 4.23.1 to 4.23.3
✅  npm/ini                       chore: bump @npmcli/template-oss from 4.23.1 to 4.23.3
❌  npm/map-workspaces            chore: bump @npmcli/template-oss from 4.22.0 to 4.23.3
✅  npm/minify-registry-metadata  chore: bump @npmcli/template-oss from 4.22.0 to 4.23.3
❌  npm/minipass-fetch            chore: bump @npmcli/template-oss from 4.22.0 to 4.23.3
✅  npm/npm-package-arg           chore: bump @npmcli/template-oss from 4.23.1 to 4.23.3
❌  npm/npm-packlist              chore: bump @npmcli/template-oss from 4.22.0 to 4.23.3
❌  npm/npm-pick-manifest         chore: bump @npmcli/template-oss from 4.22.0 to 4.23.3
❌  npm/query                     chore: bump @npmcli/template-oss from 4.22.0 to 4.23.3
✅  npm/ssri                      chore: bump @npmcli/template-oss from 4.22.0 to 4.23.3
✅  npm/stafftools                chore: bump @npmcli/template-oss from 4.23.1 to 4.23.3
?   npm/types                     chore: bump @npmcli/template-oss from 4.22.0 to 4.23.3
🔄  npm/unique-slug               chore: bump @npmcli/template-oss from 4.23.1 to 4.23.3

Press any key to continue or CTRL+C to exit
```

### After

```
% ./bin/gh.mjs template-oss-fix --author null
Running worker "template-oss-fix" which will "Fix failing template-oss pull requests" on the following items:
?   npm/cmd-shim           chore: bump @npmcli/template-oss from 4.23.1 to 4.23.3
?   npm/hosted-git-info    chore: bump @npmcli/template-oss from 4.23.1 to 4.23.3
❌  npm/map-workspaces     chore: bump @npmcli/template-oss from 4.22.0 to 4.23.3
❌  npm/minipass-fetch     chore: bump @npmcli/template-oss from 4.22.0 to 4.23.3
❌  npm/npm-packlist       chore: bump @npmcli/template-oss from 4.22.0 to 4.23.3
❌  npm/npm-pick-manifest  chore: bump @npmcli/template-oss from 4.22.0 to 4.23.3
❌  npm/query              chore: bump @npmcli/template-oss from 4.22.0 to 4.23.3
?   npm/types              chore: bump @npmcli/template-oss from 4.22.0 to 4.23.3

Press any key to continue or CTRL+C to exit
```

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
