### PR TITLE
fix: serialize worker execution for items in the same repo

### DIFF
--- a/lib/gh/index.mjs
+++ b/lib/gh/index.mjs
@@ -95,6 +95,22 @@ const run = async ({
     commandsKey: 'before',
   })
 
+  // Per-repo locks to prevent concurrent git operations on the same repo.
+  // Multiple PRs from the same repo (e.g. npm/pacote#473 and #474) would race on .git/config if processed in parallel.
+  const repoLocks = new Map()
+  const acquireRepoLock = (repoKey) => {
+    if (!repoLocks.has(repoKey)) {
+      repoLocks.set(repoKey, Promise.resolve())
+    }
+    let release
+    const prev = repoLocks.get(repoKey)
+    const next = new Promise((resolve) => {
+      release = resolve
+    })
+    repoLocks.set(repoKey, next)
+    return prev.then(() => release)
+  }
+
   const res = await PromisePool.withConcurrency(limit)
     .for(render.init(items))
     .handleError(async (error, _, pool) => {
@@ -103,15 +119,23 @@ const run = async ({
       abortError = error
       return pool.stop()
     })
-    .process(async (item) => ({
-      ...item,
-      result: await runWorker({
-        item,
-        render,
-        worker: worker.path,
-        workerData,
-      }),
-    }))
+    .process(async (item) => {
+      const repoKey = `${item.owner}/${item.name}`
+      const release = await acquireRepoLock(repoKey)
+      try {
+        return {
+          ...item,
+          result: await runWorker({
+            item,
+            render,
+            worker: worker.path,
+            workerData,
+          }),
+        }
+      } finally {
+        release()
+      }
+    })
 
   render.done()
 


### PR DESCRIPTION
## Problem

When multiple items target the same repo (e.g. `npm/pacote#473` and `npm/pacote#474`), concurrent workers race on `.git/config` during `clone`/`set-default`, causing lock contention errors:

```
error: could not lock config file .git/config: File exists
failed to run git: exit status 5
```

## Fix

Adds per-repo locks in the worker pool so items from the same repo are processed sequentially, while items from different repos still run in parallel.

## Testing

Existing tests pass. Verified manually with `template-oss-fix` against repos with multiple open PRs.